### PR TITLE
Adds support for docker with each example app

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,21 +32,25 @@ If you choose to do this, feel free to delete the other language backends from y
 - [PHP](api/php)
 - [Java](api/java)
 
-### Running locally
+### How to run
 
-These examples are meant to be run locally, allowing you to easily experiment with
-modifications and get running quickly.
+Each example can be run either locally or through [Docker](https://docs.docker.com/), allowing you to easily experiment with modifications and get running quickly.
 
-Simply clone this repository, read through the simple application code to
+You should adjust the code to fit your specific redirection and error handling needs, but the example applications are designed to perform essential API functions on first boot.
+
+**Note**: These examples are purely for demonstration purposes and we do not recommend using them as the foundation of a production system.
+
+#### Docker
+
+Each example includes a Dockerfile and a docker-compose.yml file to allow them to be run through [Docker](https://docs.docker.com/).
+
+To run any of the examples through Docker, clone this repository, update the [docker.env file at the root of level of the project](https://github.com/recurly/recurly-integration-examples/blob/main/docker.env) with values corresponding to your recurly site, and run `docker-compose up` inside the directory of any of the examples.
+
+#### Local
+
+To run locally, simply clone this repository, read through the simple application code to
 familiarize yourself, and follow the startup instructions in one of the [API
 token usage examples](api) above.
-
-You'll want to adjust the code to fit your specific redirection and error
-handling needs, but the example applications are designed to perform essential
-API functions on first boot.
-
-**Note**: These examples are purely for demonstration purposes and we do not recommend
-using them as the foundation of a production system.
 
 #### Configuring the examples
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You should adjust the code to fit your specific redirection and error handling n
 
 Each example includes a Dockerfile and a docker-compose.yml file to allow them to be run through [Docker](https://docs.docker.com/).
 
-To run any of the examples through Docker, clone this repository, update the [docker.env file at the root of level of the project](https://github.com/recurly/recurly-integration-examples/blob/main/docker.env) with values corresponding to your recurly site, and run `docker-compose up` inside the directory of any of the examples.
+To run any of the examples through Docker, clone this repository, update the [docker.env file at the root of level of the project](https://github.com/recurly/recurly-integration-examples/blob/main/docker.env) with values corresponding to your Recurly site, and run `docker-compose up` inside the directory of any of the examples.
 
 #### Local
 

--- a/api/java/Dockerfile
+++ b/api/java/Dockerfile
@@ -8,8 +8,6 @@ COPY ./api/java ./java
 # For more info, see http://sparkjava.com/documentation#static-files
 COPY ./public ./src/main/resources/public
 
-RUN cd java && mvn clean compile
-
 EXPOSE 9001
 
-CMD cd java && mvn exec:java -Dexec.mainClass="com.recurly.examples.App"
+CMD cd java && mvn clean compile && mvn exec:java -Dexec.mainClass="com.recurly.examples.App"

--- a/api/java/Dockerfile
+++ b/api/java/Dockerfile
@@ -1,4 +1,4 @@
-FROM maven:3.6.3
+FROM maven:3
 
 WORKDIR /usr/src/app
 

--- a/api/java/Dockerfile
+++ b/api/java/Dockerfile
@@ -1,0 +1,13 @@
+FROM maven:3.6.3
+
+WORKDIR /usr/src/app
+
+COPY ./api/java .
+
+COPY ./public ./src/main/resources/public
+
+RUN mvn clean compile
+
+EXPOSE 9001
+
+CMD mvn exec:java -Dexec.mainClass="com.recurly.examples.App"

--- a/api/java/Dockerfile
+++ b/api/java/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /usr/src/app
 
 COPY ./api/java .
 
+# src/main/resources is the expected directory for serving static files
+# For more info, see http://sparkjava.com/documentation#static-files
 COPY ./public ./src/main/resources/public
 
 RUN mvn clean compile

--- a/api/java/Dockerfile
+++ b/api/java/Dockerfile
@@ -2,14 +2,14 @@ FROM maven:3
 
 WORKDIR /usr/src/app
 
-COPY ./api/java .
+COPY ./api/java ./java
 
 # src/main/resources is the expected directory for serving static files
 # For more info, see http://sparkjava.com/documentation#static-files
 COPY ./public ./src/main/resources/public
 
-RUN mvn clean compile
+RUN cd java && mvn clean compile
 
 EXPOSE 9001
 
-CMD mvn exec:java -Dexec.mainClass="com.recurly.examples.App"
+CMD cd java && mvn exec:java -Dexec.mainClass="com.recurly.examples.App"

--- a/api/java/README.md
+++ b/api/java/README.md
@@ -21,6 +21,18 @@ within another application framework altogether.
 
 ### Use
 
+#### Docker
+
+1. If you haven't already, [install docker](https://www.docker.com/get-started).
+
+2. Update the values in docker.env at the (root of the repo)[https://github.com/recurly/recurly-integration-examples/blob/main/docker.env]
+
+3. Run `docker-compose up --build`
+
+4. Open [http://localhost:9001](http://localhost:9001)
+
+#### Local
+
 1. Install dependencies
 
 The Recurly Java library is distributed via [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22com.ning.billing%22%20AND%20a%3A%22recurly-java-library%22):

--- a/api/java/docker-compose.yml
+++ b/api/java/docker-compose.yml
@@ -6,10 +6,10 @@ services:
       dockerfile: ./api/java/Dockerfile
     volumes:
       - .:/usr/src/app/java
-      - ../../public:/usr/src/main/resources/public
+      - ../../public:/usr/src/app/src/main/resources/public
     ports:
       - "9001:9001"
     env_file:
       - ../../docker.env
     environment:
-      - PUBLIC_DIR_PATH=/public
+      - PUBLIC_DIR_PATH=/usr/src/app/src/main/resources/public

--- a/api/java/docker-compose.yml
+++ b/api/java/docker-compose.yml
@@ -4,6 +4,9 @@ services:
     build:
       context: ../..
       dockerfile: ./api/java/Dockerfile
+    volumes:
+      - .:/usr/src/app/java
+      - ../../public:/usr/src/app/public
     ports:
       - "9001:9001"
     env_file:

--- a/api/java/docker-compose.yml
+++ b/api/java/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: ./api/java/Dockerfile
     volumes:
       - .:/usr/src/app/java
-      - ../../public:/usr/src/app/public
+      - ../../public:/usr/src/main/resources/public
     ports:
       - "9001:9001"
     env_file:

--- a/api/java/docker-compose.yml
+++ b/api/java/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+  app:
+    build:
+      context: ../..
+      dockerfile: ./api/java/Dockerfile
+    ports:
+      - "9001:9001"
+    env_file:
+      - ../../docker.env
+    environment:
+      - PUBLIC_DIR_PATH=/public

--- a/api/java/src/main/java/com/recurly/App.java
+++ b/api/java/src/main/java/com/recurly/App.java
@@ -24,10 +24,15 @@ public class App {
     String publicKey = System.getenv("RECURLY_PUBLIC_KEY");
     String successUrl = System.getenv("SUCCESS_URL");
     String errorUrl = System.getenv("ERROR_URL");
+    String publicDirPath = System.getenv("PUBLIC_DIR_PATH");
 
     RecurlyClient recurlyClient = new RecurlyClient(apiKey, subdomain);
     setPort(9001);
-    externalStaticFileLocation("../../public");
+    if (publicDirPath == null) {
+      externalStaticFileLocation("../../public");
+    } else {
+      staticFiles.location("/public");
+    }
 
     /* POST route to handle a new subscription form */
     post("/api/subscriptions/new", (req, res) -> {

--- a/api/java/src/main/java/com/recurly/App.java
+++ b/api/java/src/main/java/com/recurly/App.java
@@ -31,7 +31,7 @@ public class App {
     if (publicDirPath == null) {
       externalStaticFileLocation("../../public");
     } else {
-      staticFiles.location("/public");
+      staticFiles.location(publicDirPath);
     }
 
     /* POST route to handle a new subscription form */

--- a/api/java/src/main/java/com/recurly/App.java
+++ b/api/java/src/main/java/com/recurly/App.java
@@ -24,14 +24,14 @@ public class App {
     String publicKey = System.getenv("RECURLY_PUBLIC_KEY");
     String successUrl = System.getenv("SUCCESS_URL");
     String errorUrl = System.getenv("ERROR_URL");
-    String publicDirPath = System.getenv("PUBLIC_DIR_PATH");
+    String publicDir = System.getenv("PUBLIC_DIR_PATH");
 
     RecurlyClient recurlyClient = new RecurlyClient(apiKey, subdomain);
     setPort(9001);
-    if (publicDirPath == null) {
-      externalStaticFileLocation("../../public");
+    if (publicDir != null) {
+      staticFiles.externalLocation(publicDir);
     } else {
-      staticFiles.location(publicDirPath);
+      externalStaticFileLocation("../../public");
     }
 
     /* POST route to handle a new subscription form */

--- a/api/node/Dockerfile
+++ b/api/node/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:12
+
+WORKDIR /usr/src/app
+
+COPY ./api/node .
+
+RUN npm install
+
+COPY ./public ./public
+
+EXPOSE 9001
+
+CMD node app.js

--- a/api/node/Dockerfile
+++ b/api/node/Dockerfile
@@ -2,12 +2,12 @@ FROM node:12
 
 WORKDIR /usr/src/app
 
-COPY ./api/node .
+COPY ./api/node ./node
 
-RUN npm install
+RUN cd ./node && npm install
 
 COPY ./public ./public
 
 EXPOSE 9001
 
-CMD node app.js
+CMD node node/app.js

--- a/api/node/README.md
+++ b/api/node/README.md
@@ -20,6 +20,18 @@ framework.
 
 ### Use
 
+#### Docker
+
+1. If you haven't already, [install docker](https://www.docker.com/get-started).
+
+2. Update the values in docker.env at the (root of the repo)[https://github.com/recurly/recurly-integration-examples/blob/main/docker.env]
+
+3. Run `docker-compose up --build`
+
+4. Open [http://localhost:9001](http://localhost:9001)
+
+#### Local
+
 1. Start the server
 
   ```bash

--- a/api/node/app.js
+++ b/api/node/app.js
@@ -18,7 +18,8 @@ const {
   RECURLY_API_KEY,
   RECURLY_PUBLIC_KEY,
   SUCCESS_URL,
-  ERROR_URL
+  ERROR_URL,
+  PUBLIC_DIR_PATH
 } = process.env;
 
 // Instantiate a configured recurly client
@@ -109,7 +110,9 @@ app.get('/config', function (req, res) {
 });
 
 // Mounts express.static to render example forms
-app.use(express.static(__dirname + '/../../public'));
+const pubDirPath = PUBLIC_DIR_PATH || '/../../public';
+
+app.use(express.static(__dirname + pubDirPath));
 
 // Start the server
 app.listen(9001, function () {

--- a/api/node/docker-compose.yml
+++ b/api/node/docker-compose.yml
@@ -4,6 +4,9 @@ services:
     build:
       context: ../..
       dockerfile: ./api/node/Dockerfile
+    volumes:
+      - .:/usr/src/app/ruby
+      - ../../public:/usr/src/app/public
     ports:
       - "9001:9001"
     env_file:

--- a/api/node/docker-compose.yml
+++ b/api/node/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: ../..
       dockerfile: ./api/node/Dockerfile
     volumes:
-      - .:/usr/src/app/ruby
+      - .:/usr/src/app/node
       - ../../public:/usr/src/app/public
     ports:
       - "9001:9001"

--- a/api/node/docker-compose.yml
+++ b/api/node/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+  app:
+    build:
+      context: ../..
+      dockerfile: ./api/node/Dockerfile
+    ports:
+      - "9001:9001"
+    env_file:
+      - ../../docker.env
+    environment:
+      - PUBLIC_DIR_PATH=/public

--- a/api/php/Dockerfile
+++ b/api/php/Dockerfile
@@ -1,10 +1,8 @@
-FROM php:7.4-cli
+FROM composer:2
 
 WORKDIR /usr/src/app
 
 COPY ./api/php .
-
-RUN curl -sS https://getcomposer.org/installer | php
 
 RUN php composer.phar install
 

--- a/api/php/Dockerfile
+++ b/api/php/Dockerfile
@@ -1,0 +1,15 @@
+FROM php:7.4-cli
+
+WORKDIR /usr/src/app
+
+COPY ./api/php .
+
+RUN curl -sS https://getcomposer.org/installer | php
+
+RUN php composer.phar install
+
+COPY ./public ./public
+
+EXPOSE 9001
+
+CMD php -S 0.0.0.0:9001 -t ./public app.php

--- a/api/php/Dockerfile
+++ b/api/php/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /usr/src/app
 
 COPY ./api/php .
 
-RUN php composer.phar install
+RUN composer install
 
 COPY ./public ./public
 

--- a/api/php/README.md
+++ b/api/php/README.md
@@ -22,6 +22,18 @@ within another application framework altogehter.
 
 ### Use
 
+#### Docker
+
+1. If you haven't already, [install docker](https://www.docker.com/get-started).
+
+2. Update the values in docker.env at the (root of the repo)[https://github.com/recurly/recurly-integration-examples/blob/main/docker.env]
+
+3. Run `docker-compose up --build`
+
+4. Open [http://localhost:9001](http://localhost:9001)
+
+#### Local
+
 1. Install dependencies using [Composer][composer]. These instructions assume a global composer
    executable.
 

--- a/api/php/app.php
+++ b/api/php/app.php
@@ -7,7 +7,8 @@ use Slim\Factory\AppFactory;
 if (PHP_SAPI == 'cli-server') {
   $url  = parse_url($_SERVER['REQUEST_URI']);
   $path = $url['path'] == '/' ? 'index.html' : $url['path'];
-  $file = __DIR__ . "/../../public/$path";
+  $public_dir = getenv('PUBLIC_DIR_PATH') ? getenv('PUBLIC_DIR_PATH') : '/../../public';
+  $file = __DIR__ . "$public_dir/$path";
   if (is_file($file)) return false;
 }
 
@@ -15,7 +16,7 @@ require 'vendor/autoload.php';
 
 // Configure the client with your API Key. We're using ENV vars here,
 // but you may wish to store them elsewhere
-$recurly_client = new \Recurly\Client($_ENV['RECURLY_API_KEY']);
+$recurly_client = new \Recurly\Client(getenv('RECURLY_API_KEY'));
 
 $app = AppFactory::create();
 
@@ -156,7 +157,8 @@ $app->put('/api/accounts/{account_code}', function (Request $request, Response $
 
 // This endpoint provides configuration to recurly.js
 $app->get('/config', function (Request $request, Response $response, array $args) {
-  $response->getBody()->write("window.recurlyConfig = { publicKey: '$_ENV[RECURLY_PUBLIC_KEY]' }");
+  $PUBLIC_KEY = getenv('RECURLY_PUBLIC_KEY');
+  $response->getBody()->write("window.recurlyConfig = { publicKey: '$PUBLIC_KEY' }");
   return $response->withHeader('Content-Type', 'application/javascript');
 });
 

--- a/api/php/docker-compose.yml
+++ b/api/php/docker-compose.yml
@@ -8,3 +8,5 @@ services:
       - "9001:9001"
     env_file:
       - ../../docker.env
+    environment:
+      - PUBLIC_DIR_PATH=/public

--- a/api/php/docker-compose.yml
+++ b/api/php/docker-compose.yml
@@ -4,6 +4,9 @@ services:
     build:
       context: ../..
       dockerfile: ./api/php/Dockerfile
+    volumes:
+      - .:/usr/src/app/php
+      - ../../public:/usr/src/app/public
     ports:
       - "9001:9001"
     env_file:

--- a/api/php/docker-compose.yml
+++ b/api/php/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+services:
+  app:
+    build:
+      context: ../..
+      dockerfile: ./api/php/Dockerfile
+    ports:
+      - "9001:9001"
+    env_file:
+      - ../../docker.env

--- a/api/python/Dockerfile
+++ b/api/python/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3
+
+WORKDIR /usr/src/app
+
+COPY ./api/python .
+
+RUN pip install -r requirements.txt
+
+COPY ./public ./public
+
+EXPOSE 9001
+
+CMD FLASK_APP=app.py flask run -p 9001 --host 0.0.0.0

--- a/api/python/Dockerfile
+++ b/api/python/Dockerfile
@@ -2,12 +2,12 @@ FROM python:3
 
 WORKDIR /usr/src/app
 
-COPY ./api/python .
+COPY ./api/python ./python
 
-RUN pip install -r requirements.txt
+RUN cd python && pip install -r requirements.txt
 
 COPY ./public ./public
 
 EXPOSE 9001
 
-CMD FLASK_APP=app.py flask run -p 9001 --host 0.0.0.0
+CMD FLASK_APP=python/app.py flask run -p 9001 --host 0.0.0.0

--- a/api/python/README.md
+++ b/api/python/README.md
@@ -21,6 +21,18 @@ framework.
 
 ### Use
 
+#### Docker
+
+1. If you haven't already, [install docker](https://www.docker.com/get-started).
+
+2. Update the values in docker.env at the (root of the repo)[https://github.com/recurly/recurly-integration-examples/blob/main/docker.env]
+
+3. Run `docker-compose up --build`
+
+4. Open [http://localhost:9001](http://localhost:9001)
+
+#### Local
+
 1. Start the server
 
   ```bash

--- a/api/python/app.py
+++ b/api/python/app.py
@@ -20,7 +20,8 @@ RECURLY_PUBLIC_KEY = os.environ['RECURLY_PUBLIC_KEY']
 SUCCESS_URL = os.environ['SUCCESS_URL']
 ERROR_URL = os.environ['ERROR_URL']
 
-app = Flask(__name__, static_folder='../../public', static_url_path='')
+PUBLIC_DIR_PATH = os.getenv('PUBLIC_DIR_PATH', '../../public')
+app = Flask(__name__, static_folder=PUBLIC_DIR_PATH, static_url_path='')
 
 # GET route to show the list of options
 @app.route("/", methods=['GET'])

--- a/api/python/docker-compose.yml
+++ b/api/python/docker-compose.yml
@@ -4,6 +4,9 @@ services:
     build:
       context: ../..
       dockerfile: ./api/python/Dockerfile
+    volumes:
+      - .:/usr/src/app/ruby
+      - ../../public:/usr/src/app/public
     ports:
       - "9001:9001"
     env_file:

--- a/api/python/docker-compose.yml
+++ b/api/python/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+  app:
+    build:
+      context: ../..
+      dockerfile: ./api/python/Dockerfile
+    ports:
+      - "9001:9001"
+    env_file:
+      - ../../docker.env
+    environment:
+      - PUBLIC_DIR_PATH=./public

--- a/api/python/docker-compose.yml
+++ b/api/python/docker-compose.yml
@@ -5,7 +5,7 @@ services:
       context: ../..
       dockerfile: ./api/python/Dockerfile
     volumes:
-      - .:/usr/src/app/ruby
+      - .:/usr/src/app/python
       - ../../public:/usr/src/app/public
     ports:
       - "9001:9001"

--- a/api/ruby/Dockerfile
+++ b/api/ruby/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5
+FROM ruby:2
 
 WORKDIR /usr/src/app
 

--- a/api/ruby/Dockerfile
+++ b/api/ruby/Dockerfile
@@ -2,12 +2,12 @@ FROM ruby:2
 
 WORKDIR /usr/src/app
 
-COPY ./api/ruby .
+COPY ./api/ruby ./ruby
 
-RUN bundle install
+RUN cd ruby && bundle install
 
 COPY ./public ./public
 
 EXPOSE 9001
 
-CMD ruby app.rb
+CMD ruby ruby/app.rb

--- a/api/ruby/Dockerfile
+++ b/api/ruby/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:2.5
+
+WORKDIR /usr/src/app
+
+COPY ./api/ruby .
+
+RUN bundle install
+
+COPY ./public ./public
+
+EXPOSE 9001
+
+CMD ruby app.rb

--- a/api/ruby/README.md
+++ b/api/ruby/README.md
@@ -20,7 +20,19 @@ application framework.
 - `POST` [/api/accounts/new](app.rb#L108-120)
 - `PUT` [/api/accounts/:account_code](app.rb#L123-136)
 
-### Local Development
+### Use
+
+#### Docker
+
+1. If you haven't already, [install docker](https://www.docker.com/get-started).
+
+2. Update the values in docker.env at the (root of the repo)[https://github.com/recurly/recurly-integration-examples/blob/main/docker.env]
+
+3. Run `docker-compose up --build`
+
+4. Open [http://localhost:9001](http://localhost:9001)
+
+#### Local
 
 1. Start the server
 

--- a/api/ruby/app.rb
+++ b/api/ruby/app.rb
@@ -15,7 +15,9 @@ Dotenv.load
 set :port, ENV['PORT'] || 9001
 set :public_folder, ENV['PUBLIC_PATH'] || 'public'
 
-enable :static
+set :port, 9001
+set :bind, '0.0.0.0'
+set :public_folder, ENV['PUBLIC_DIR_PATH'] || '../../public'
 enable :logging
 
 success_url = ENV['SUCCESS_URL']

--- a/api/ruby/docker-compose.yml
+++ b/api/ruby/docker-compose.yml
@@ -4,6 +4,9 @@ services:
     build:
       context: ../..
       dockerfile: ./api/ruby/Dockerfile
+    volumes:
+      - .:/usr/src/app/ruby
+      - ../../public:/usr/src/app/public
     ports:
       - "9001:9001"
     env_file:

--- a/api/ruby/docker-compose.yml
+++ b/api/ruby/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+  app:
+    build:
+      context: ../..
+      dockerfile: ./api/ruby/Dockerfile
+    ports:
+      - "9001:9001"
+    env_file:
+      - ../../docker.env
+    environment:
+      - PUBLIC_DIR_PATH=./public

--- a/docker.env
+++ b/docker.env
@@ -1,0 +1,6 @@
+# Change these values to configure for running any of the examples with docker
+RECURLY_SUBDOMAIN=
+RECURLY_API_KEY=
+RECURLY_PUBLIC_KEY=
+SUCCESS_URL=
+ERROR_URL=


### PR DESCRIPTION
Just a couple notes:

- Because the `public` directory is at the root of the repo, the build context for each of the examples needed to be set there to `COPY` that directory over into the image.
- To preserve the capability to run the examples locally, I added an environment variable `PUBLIC_DIR_PATH` to some of the examples to specify where the static directory should be served from. Because this value is slightly different in some of the examples and php doesn't need it, that value is specified in the example app's `docker-compose.yml` files