### PR TITLE
Updates frontend examples to use Elements

### DIFF
--- a/public/3d-secure/index.html
+++ b/public/3d-secure/index.html
@@ -23,7 +23,7 @@
     <section>
       <form method="post" action="/api/subscriptions/new">
         <div>
-          <div data-recurly="card"></div>
+          <div data-my-js-ref="recurly-element-card"></div>
         </div>
         <div>
           <label for="first_name">First Name</label>
@@ -40,17 +40,18 @@
       </form>
     </section>
     <script>
-      recurly.configure({
-        publicKey: window.recurlyConfig.publicKey,
+      recurly.configure(window.recurlyConfig.publicKey);
+
+      var elements = recurly.Elements();
+      var cardElement = elements.CardElement({
         style: {
-          all: {
-            fontFamily: 'Open Sans',
-            fontSize: '1rem',
-            fontWeight: 'bold',
-            fontColor: '#2c0730'
-          }
+          fontFamily: 'Open Sans',
+          fontSize: '1rem',
+          fontWeight: 'bold',
+          fontColor: '#2c0730'
         }
       });
+      cardElement.attach('[data-my-js-ref="recurly-element-card"]');
 
       $('form').on('submit', function (event) {
         event.preventDefault();
@@ -60,7 +61,7 @@
         $('button').prop('disabled', true);
 
         var form = this;
-        recurly.token(form, function (err, token) {
+        recurly.token(elements, form, function (err, token) {
           if (err) error(err);
           else form.submit();
         });

--- a/public/advanced-bank-account/index.html
+++ b/public/advanced-bank-account/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>Recurly.js Example: Advanced Pricing</title>
-    <script src="https://js.lvh.me:8020/build/recurly.js"></script>
+    <script src="https://js.recurly.com/v4/recurly.js"></script>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
     <script src="/config"></script>
     <link href="/js/favicon.png" rel="shortcut icon" type="image/png">

--- a/public/advanced-bank-account/index.html
+++ b/public/advanced-bank-account/index.html
@@ -141,8 +141,8 @@
       <input type="hidden" data-recurly="token" name="recurly-token">
     </form>
     <script>
-      // Configure recurly.js
-      recurly.configure({api: "https://api.lvh.me:3000/js/v1", publicKey: "dev-LvCTlJaL5bKTD6pEtar7Bx"}); // Set this to your own public key
+      // Configure recurly.js -- set this to your own public key
+      recurly.configure(window.recurlyConfig.publicKey);
 
       // On form submit, we stop submission to go get the token
       $('form').on('submit', function (event) {
@@ -160,7 +160,7 @@
         var form = this;
 
         // Now we call recurly.token with the form. It goes to Recurly servers
-        // to tokenize the credit card information, then injects the token into the
+        // to tokenize the bank account information, then injects the token into the
         // data-recurly="token" field above
         recurly.bankAccount.token(this, function (err, token) {
 

--- a/public/advanced-pricing-items/index.html
+++ b/public/advanced-pricing-items/index.html
@@ -21,7 +21,7 @@
     <section id="errors" class="errors"></section>
 
     <section>
-      <form method="post" action="/api/purchases/new">
+      <form method="post" action="/api/subscriptions/new">
         <div>
           <label for="plan">Select a plan</label>
           <select name="subscriptions[][plan-code]" class="js-plan-select" id="plan"></select>
@@ -43,7 +43,7 @@
         </div>
 
         <div>
-          <div data-recurly="card"></div>
+          <div data-my-js-ref="recurly-element-card"></div>
         </div>
 
         <div>
@@ -77,16 +77,23 @@
       const itemsSelect = document.querySelector('.js-items-select');
 
       // Configure recurly.js
-      recurly.configure({
-        publicKey, // Set this to your own public key
+      recurly.configure(window.recurlyConfig.publicKey);
+
+      // Create a CardElement
+      var elements = recurly.Elements();
+      var cardElement = elements.CardElement({
         style: {
-          all: {
-            fontFamily: 'Open Sans',
-            fontSize: '1rem',
-            fontWeight: 'bold',
-            fontColor: '#2c0730'
-          }
+          fontFamily: 'Open Sans',
+          fontSize: '1rem',
+          fontWeight: 'bold',
+          fontColor: '#2c0730'
         }
+      });
+      cardElement.attach('[data-my-js-ref="recurly-element-card"]');
+
+      // When a customer hits their 'enter' key while using the card element
+      cardElement.on('submit', function (event) {
+        $('form').submit();
       });
 
       // Configure form submission

--- a/public/advanced-pricing-items/index.html
+++ b/public/advanced-pricing-items/index.html
@@ -21,7 +21,7 @@
     <section id="errors" class="errors"></section>
 
     <section>
-      <form method="post" action="/api/subscriptions/new">
+      <form method="post" action="/api/purchases/new">
         <div>
           <label for="plan">Select a plan</label>
           <select name="subscriptions[][plan-code]" class="js-plan-select" id="plan"></select>

--- a/public/advanced-pricing/index.html
+++ b/public/advanced-pricing/index.html
@@ -25,18 +25,19 @@
       <label for="plan-quantity">Quantity</label>
       <input type="text" data-recurly="plan_quantity" id="plan-quantity" value="2">
 
-      <label for="number">Card Number</label>
-      <div data-recurly="number" id="number"></div>
-      <label for="month">Month</label>
-      <div data-recurly="month" id="month"></div>
-      <label for="year">Year</label>
-      <div data-recurly="year" id="year"></div>
-      <label for="cvv">CVV</label>
-      <div data-recurly="cvv" id="cvv"></div>
-      <label for="first_name">First Name</label>
-      <input type="text" data-recurly="first_name" id="first_name" name="first-name">
-      <label for="last_name">Last Name</label>
-      <input type="text" data-recurly="last_name" id="last_name" name="last-name">
+      <div>
+        <div data-my-js-ref="recurly-element-card"></div>
+      </div>
+
+      <div>
+        <label for="first_name">First Name</label>
+        <input type="text" data-recurly="first_name" id="first_name" name="first-name">
+      </div>
+
+      <div>
+        <label for="last_name">Last Name</label>
+        <input type="text" data-recurly="last_name" id="last_name" name="last-name">
+      </div>
 
       <label for="country">Country</label>
       <select id="country" data-recurly="country">
@@ -115,30 +116,23 @@
       <div id="errors"></div>
     </form>
     <script>
-      // Configure recurly.js
-      recurly.configure({
-        publicKey: window.recurlyConfig.publicKey, // Set this to your own public key
+      // Configure recurly.js -- set this to your own public key
+      recurly.configure(window.recurlyConfig.publicKey);
+
+      // Create a CardElement
+      var elements = recurly.Elements();
+      var cardElement = elements.CardElement({
         style: {
-          all: {
-            fontFamily: 'Open Sans',
-            fontSize: '1rem',
-            fontWeight: 'bold',
-            fontColor: '#2c0730'
-          },
-          number: {
-            placeholder: 'Card number'
-          },
-          month: {
-            placeholder: 'mm'
-          },
-          year: {
-            placeholder: 'yy'
-          }
+          fontFamily: 'Open Sans',
+          fontSize: '1rem',
+          fontWeight: 'bold',
+          fontColor: '#2c0730'
         }
       });
+      cardElement.attach('[data-my-js-ref="recurly-element-card"]');
 
-      // When a customer hits their 'enter' key while in a field
-      recurly.on('field:submit', function (event) {
+      // When a customer hits their 'enter' key while using the card element
+      cardElement.on('submit', function (event) {
         $('form').submit();
       });
 
@@ -160,7 +154,7 @@
         // Now we call recurly.token with the form. It goes to Recurly servers
         // to tokenize the credit card information, then injects the token into the
         // data-recurly="token" field above
-        recurly.token(this, function (err, token) {
+        recurly.token(elements, this, function (err, token) {
 
           // send any errors to the error function below
           if (err) error(err);

--- a/public/advanced-tax/index.html
+++ b/public/advanced-tax/index.html
@@ -25,16 +25,19 @@
       <label for="plan-quantity">Quantity</label>
       <input type="text" data-recurly="plan_quantity" id="plan-quantity" value="2">
 
-      <label for="number">Card Number</label>
-      <div data-recurly="number" id="number"></div>
-      <label for="month">Month</label>
-      <div data-recurly="month" id="month"></div>
-      <label for="year">Year</label>
-      <div data-recurly="year" id="year"></div>
-      <label for="first_name">First Name</label>
-      <input type="text" data-recurly="first_name" id="first_name">
-      <label for="last_name">Last Name</label>
-      <input type="text" data-recurly="last_name" id="last_name">
+      <div>
+        <div data-my-js-ref="recurly-element-card"></div>
+      </div>
+
+      <div>
+        <label for="first_name">First Name</label>
+        <input type="text" data-recurly="first_name" id="first_name" name="first-name">
+      </div>
+
+      <div>
+        <label for="last_name">Last Name</label>
+        <input type="text" data-recurly="last_name" id="last_name" name="last-name">
+      </div>
 
       <label for="country">Country</label>
       <select id="country" data-recurly="country">
@@ -117,30 +120,23 @@
       <div id="errors"></div>
     </form>
     <script>
-      // Configure recurly.js
-      recurly.configure({
-        publicKey: window.recurlyConfig.publicKey, // Set this to your own public key
+      // Configure recurly.js -- set this to your own public key
+      recurly.configure(window.recurlyConfig.publicKey);
+
+      // Create a CardElement
+      var elements = recurly.Elements();
+      var cardElement = elements.CardElement({
         style: {
-          all: {
-            fontFamily: 'Open Sans',
-            fontSize: '1rem',
-            fontWeight: 'bold',
-            fontColor: '#2c0730'
-          },
-          number: {
-            placeholder: ''
-          },
-          month: {
-            placeholder: 'mm'
-          },
-          year: {
-            placeholder: 'yy'
-          }
+          fontFamily: 'Open Sans',
+          fontSize: '1rem',
+          fontWeight: 'bold',
+          fontColor: '#2c0730'
         }
       });
+      cardElement.attach('[data-my-js-ref="recurly-element-card"]');
 
-      // When a customer hits their 'enter' key while in a field
-      recurly.on('field:submit', function (event) {
+      // When a customer hits their 'enter' key while using the card element
+      cardElement.on('submit', function (event) {
         $('form').submit();
       });
 
@@ -162,7 +158,7 @@
         // Now we call recurly.token with the form. It goes to Recurly servers
         // to tokenize the credit card information, then injects the token into the
         // data-recurly="token" field above
-        recurly.token(this, function (err, token) {
+        recurly.token(elements, this, function (err, token) {
 
           // send any errors to the error function below
           if (err) error(err);

--- a/public/adyen/index.html
+++ b/public/adyen/index.html
@@ -11,11 +11,11 @@
   </head>
   <body>
     <script>
-      var adyen = recurly.Adyen({});
+      var adyen = recurly.Adyen();
 
       adyen.on('token', function (response) {
-        console.log(response)
-        alert(response.authResult)
+        console.log(response);
+        alert(response.authResult);
       });
 
       $("#adyen-subscribe").on('click', function (event) {
@@ -23,10 +23,10 @@
         event.preventDefault();
         // Start the adyen checkout flow;
         // These values can come from a checkout form, or can be hard-coded
-        // Depending on the use case. 
+        // Depending on the use case.
         var payload = {invoiceUuid: "aasdf1234", skinCode: "1234asdf", countryCode: "PL", shopperLocale: "en_PL"};
         adyen.start(payload);
-      }); 
+      });
     </script>
 
     <form id="rig-payment-form" action="#">

--- a/public/apple-pay/index.html
+++ b/public/apple-pay/index.html
@@ -78,8 +78,8 @@
       </form>
     </section>
     <script>
-      // Configure recurly.js
-      recurly.configure(window.recurlyConfig.publicKey); // Set this to your own public key
+      // Configure recurly.js -- set this to your own public key
+      recurly.configure(window.recurlyConfig.publicKey);
 
       recurly.ready(function () {
         var button = document.querySelector('#apple-pay')

--- a/public/fraud-detection/braintree.html
+++ b/public/fraud-detection/braintree.html
@@ -27,7 +27,7 @@
     <section>
       <form method="post" action="/api/subscriptions/new">
         <div>
-          <div data-recurly="card"></div>
+          <div data-my-js-ref="recurly-element-card"></div>
         </div>
 
         <div>
@@ -69,18 +69,23 @@
 
           // Configure recurly.js with the Braintree deviceData
           recurly.configure({
-            publicKey: window.recurlyConfig.publicKey, // Set this to your own public key
-            style: {
-              all: {
-                fontFamily: 'Open Sans',
-                fontSize: '1rem',
-                fontWeight: 'bold',
-                fontColor: '#2c0730'
-              }
-            },
+            // Set this to your own public key
+            publicKey: window.recurlyConfig.publicKey,
             // If you are using Braintree's fraud management integration, set the following
             fraud: { braintree: { deviceData: deviceData } }
           });
+
+          // Create a CardElement
+          var elements = recurly.Elements();
+          var cardElement = elements.CardElement({
+            style: {
+              fontFamily: 'Open Sans',
+              fontSize: '1rem',
+              fontWeight: 'bold',
+              fontColor: '#2c0730'
+            }
+          });
+          cardElement.attach('[data-my-js-ref="recurly-element-card"]');
 
           // On form submit, we stop submission to go get the token
           $('form').on('submit', function (event) {
@@ -100,7 +105,7 @@
             // Now we call recurly.token with the form. It goes to Recurly servers
             // to tokenize the credit card information, then injects the token into the
             // data-recurly="token" field above
-            recurly.token(form, function (err, token) {
+            recurly.token(elements, form, function (err, token) {
 
               // send any errors to the error function below
               if (err) error(err);

--- a/public/fraud-detection/recurly-kount.html
+++ b/public/fraud-detection/recurly-kount.html
@@ -47,7 +47,7 @@
         // Set this to your own public key
         publicKey: window.recurlyConfig.publicKey,
         // If using the Recurly Fraud protection or Kount direct integration, set the following
-        fraud: { kount: { dataCollector: true } };
+        fraud: { kount: { dataCollector: true } }
       });
 
       // Create a CardElement

--- a/public/fraud-detection/recurly-kount.html
+++ b/public/fraud-detection/recurly-kount.html
@@ -23,7 +23,7 @@
     <section>
       <form method="post" action="/api/subscriptions/new">
         <div>
-          <div data-recurly="card"></div>
+          <div data-my-js-ref="recurly-element-card"></div>
         </div>
 
         <div>
@@ -44,18 +44,23 @@
     <script>
       // Configure recurly.js
       recurly.configure({
-        publicKey: window.recurlyConfig.publicKey, // Set this to your own public key
-        style: {
-          all: {
-            fontFamily: 'Open Sans',
-            fontSize: '1rem',
-            fontWeight: 'bold',
-            fontColor: '#2c0730'
-          }
-        },
+        // Set this to your own public key
+        publicKey: window.recurlyConfig.publicKey,
         // If using the Recurly Fraud protection or Kount direct integration, set the following
         fraud: { kount: { dataCollector: true } };
       });
+
+      // Create a CardElement
+      var elements = recurly.Elements();
+      var cardElement = elements.CardElement({
+        style: {
+          fontFamily: 'Open Sans',
+          fontSize: '1rem',
+          fontWeight: 'bold',
+          fontColor: '#2c0730'
+        }
+      });
+      cardElement.attach('[data-my-js-ref="recurly-element-card"]');
 
       // On form submit, we stop submission to go get the token
       $('form').on('submit', function (event) {
@@ -75,7 +80,7 @@
         // Now we call recurly.token with the form. It goes to Recurly servers
         // to tokenize the credit card information, then injects the token into the
         // data-recurly="token" field above
-        recurly.token(form, function (err, token) {
+        recurly.token(elements, form, function (err, token) {
 
           // send any errors to the error function below
           if (err) error(err);

--- a/public/gift-cards/index.html
+++ b/public/gift-cards/index.html
@@ -23,7 +23,7 @@
     <section>
       <form method="post" action="/api/subscriptions/new">
         <div>
-          <div data-recurly="card"></div>
+          <div data-my-js-ref="recurly-element-card"></div>
         </div>
 
         <div>
@@ -47,18 +47,20 @@
       </form>
     </section>
     <script>
-      // Configure recurly.js
-      recurly.configure({
-        publicKey: window.recurlyConfig.publicKey, // Set this to your own public key
+      // Configure recurly.js -- set this to your own public key
+      recurly.configure(window.recurlyConfig.publicKey);
+
+      // Create a CardElement
+      var elements = recurly.Elements();
+      var cardElement = elements.CardElement({
         style: {
-          all: {
-            fontFamily: 'Open Sans',
-            fontSize: '1rem',
-            fontWeight: 'bold',
-            fontColor: '#2c0730'
-          }
+          fontFamily: 'Open Sans',
+          fontSize: '1rem',
+          fontWeight: 'bold',
+          fontColor: '#2c0730'
         }
       });
+      cardElement.attach('[data-my-js-ref="recurly-element-card"]');
 
       // On form submit, we stop submission to go get the token
       $('form').on('submit', function (event) {
@@ -78,7 +80,7 @@
         // Now we call recurly.token with the form. It goes to Recurly servers
         // to tokenize the credit card information, then injects the token into the
         // data-recurly="token" field above
-        recurly.token(form, function (err, token) {
+        recurly.token(elements, form, function (err, token) {
 
           // send any errors to the error function below
           if (err) error(err);

--- a/public/minimal/index.html
+++ b/public/minimal/index.html
@@ -23,7 +23,7 @@
     <section>
       <form method="post" action="/api/subscriptions/new">
         <div>
-          <div data-recurly="card"></div>
+          <div data-my-js-ref="recurly-element-card"></div>
         </div>
 
         <div>
@@ -42,21 +42,23 @@
       </form>
     </section>
     <script>
-      // Configure recurly.js
-      recurly.configure({
-        publicKey: window.recurlyConfig.publicKey, // Set this to your own public key
+      // Configure recurly.js -- set this to your own public key
+      recurly.configure(window.recurlyConfig.publicKey);
+
+      // Create a CardElement
+      var elements = recurly.Elements();
+      var cardElement = elements.CardElement({
         style: {
-          all: {
-            fontFamily: 'Open Sans',
-            fontSize: '1rem',
-            fontWeight: 'bold',
-            fontColor: '#2c0730'
-          }
+          fontFamily: 'Open Sans',
+          fontSize: '1rem',
+          fontWeight: 'bold',
+          fontColor: '#2c0730'
         }
       });
+      cardElement.attach('[data-my-js-ref="recurly-element-card"]');
 
-      // When a customer hits their 'enter' key while in a field
-      recurly.on('field:submit', function (event) {
+      // When a customer hits their 'enter' key while using the card element
+      cardElement.on('submit', function (event) {
         $('form').submit();
       });
 
@@ -78,7 +80,7 @@
         // Now we call recurly.token with the form. It goes to Recurly servers
         // to tokenize the credit card information, then injects the token into the
         // data-recurly="token" field above
-        recurly.token(form, function (err, token) {
+        recurly.token(elements, form, function (err, token) {
 
           // send any errors to the error function below
           if (err) error(err);
@@ -88,27 +90,6 @@
 
         });
       });
-
-      // Reconfigure font size based on window size
-      $(window).on('resize init', function (event) {
-        if ($(this).width() < 600) {
-          recurly.configure({
-            style: {
-              all: {
-                fontSize: '0.9rem'
-              }
-            }
-          });
-        } else {
-          recurly.configure({
-            style: {
-              all: {
-                fontSize: '1rem'
-              }
-            }
-          });
-        }
-      }).triggerHandler('init');
 
       // A simple error handling function to expose errors to the customer
       function error (err) {

--- a/public/minimal/style.css
+++ b/public/minimal/style.css
@@ -82,7 +82,7 @@ input.error {
   border-color: #e43c29;
 }
 
-div.error .recurly-hosted-field {
+div.recurly-element-invalid {
   border: 2px solid #e43c29;
 }
 
@@ -192,13 +192,12 @@ figure.success {
   }
 }
 
-.recurly-hosted-field {
+.recurly-element {
   position: relative;
   width: 100%;
   height: 42px;
   border: 2px solid #c2c2c2;
   background: transparent;
-  padding: 0.5rem;
   margin: 0 0 1rem;
   outline: none;
   font-family: 'Open Sans', Helvetica, sans-serif;
@@ -215,7 +214,7 @@ figure.success {
   transition: border-color 0.3s;
 }
 
-.recurly-hosted-field-focus {
+.recurly-element-focus {
   border-color: #2c0730;
   color: #2c0730;
   z-index: 10;

--- a/public/paypal/index.html
+++ b/public/paypal/index.html
@@ -22,12 +22,14 @@
     <script>
       var form = $('form');
 
-      // Configure recurly.js
-      recurly.configure('PUBLIC_KEY');
+      // Configure recurly.js -- set this to your own public key
+      recurly.configure(window.recurlyConfig.publicKey);
 
       // Create a recurly.PayPal instance. The `displayName` is displayed to the customer in the PayPal flow window
       var paypal = recurly.PayPal({
-        display: { displayName: 'My product' }
+        display: {
+          displayName: 'My product'
+        }
       });
 
       // Handle any errors that occur during the paypal checkout


### PR DESCRIPTION
This changes all of the examples under `/public` to use [Recurly.js Elements](https://developers.recurly.com/reference/recurly-js/index.html#elements) to initialize, style, and attach fields rather than through calling `recurly.configure`.

This also includes some changes to CSS selectors to accommodate the changes.