### PR TITLE
Adds script tag for /config in PayPal example

### DIFF
--- a/public/paypal/index.html
+++ b/public/paypal/index.html
@@ -3,11 +3,11 @@
   <head>
     <title>Recurly.js Example: Minimal Billing Information</title>
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
+    <script src="/config"></script>
     <script src="https://js.recurly.com/v4/recurly.js"></script>
     <link href="/js/favicon.png" rel="shortcut icon" type="image/png">
     <link href="https://js.recurly.com/v4/recurly.css" rel="stylesheet" type="text/css">
     <link href="//fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet" type="text/css">
-    <link href="/paypal/style.css" rel="stylesheet">
     <meta name="viewport" content="width=device-width, initial-scale=1">
   </head>
   <body>


### PR DESCRIPTION
The PayPal is currently broken because `recurlyConfig` is missing. This PR just adds the script tag to pull in that resource.