### PR TITLE
Adds serverless/Netlify example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /api/php/vendor/
+/api/netlify/node_modules/
 /api/node/node_modules/
 /api/php/composer.phar
 /api/java/.java-version

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 <a href="https://heroku.com/deploy"><img align="right" height="28" src="https://www.herokucdn.com/deploy/button.png"></a>
 <a href="https://deploy.cloud.run"><img align="right" height="28" src="https://deploy.cloud.run/button.svg"></a>
+<a href="https://app.netlify.com/start/deploy?repository=https://github.com/recurly/recurly-integration-examples">
+  <img align="right" height="28" src="https://www.netlify.com/img/deploy/button.svg">
+</a>
 Recurly integration examples
 ===================
 <p align="center">
@@ -73,6 +76,8 @@ backends from your clone.
 [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
 
 [![Run on Google Cloud](https://deploy.cloud.run/button.svg)](https://deploy.cloud.run)
+
+[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/recurly/recurly-integration-examples)
 
 ### Looking for React?
 

--- a/api/netlify/functions/config.js
+++ b/api/netlify/functions/config.js
@@ -1,0 +1,9 @@
+exports.handler = async (event, context) => {
+  return {
+    statusCode: 200,
+    body: `window.recurlyConfig = { publicKey: '${process.env.RECURLY_PUBLIC_KEY}' }`,
+    headers: {
+      'Content-Type': 'application/javascript'
+    }
+  };
+};

--- a/api/netlify/functions/new-account.js
+++ b/api/netlify/functions/new-account.js
@@ -1,0 +1,36 @@
+const recurly = require('recurly');
+const uuid = require('node-uuid');
+
+const client = new recurly.Client(process.env.RECURLY_API_KEY);
+
+exports.handler = async (event, context) => {
+  const body = JSON.parse(event.body);
+
+  try {
+    const accountCreate = {
+      code: uuid.v1(),
+      billing_info: {
+        token_id: body['recurly-token']
+      }
+    }
+
+    await client.createAccount(accountCreate);
+
+    return {
+      statusCode: 301,
+      headers: {
+        Location: process.env.SUCCESS_URL
+      }
+    };
+  }
+  catch (err) {
+    const { message } = err;
+
+    return {
+      statusCode: 301,
+      headers: {
+        Location: `${process.env.ERROR_URL}?error=${message}`
+      }
+    };
+  }
+}

--- a/api/netlify/functions/new-subscription.js
+++ b/api/netlify/functions/new-subscription.js
@@ -1,0 +1,63 @@
+const recurly = require('recurly');
+const uuid = require('node-uuid');
+const querystring = require('querystring');
+
+const client = new recurly.Client(process.env.RECURLY_API_KEY);
+
+exports.handler = async (event, context) => {
+  const body = querystring.parse(event.body);
+
+  // Build our billing info hash
+  const tokenId = body['recurly-token'];
+  const code = body['recurly-account-code'] || uuid.v1();
+  const billingInfo = { token_id: tokenId };
+
+  // Optionally add a 3D Secure token if one is present. You only need to do this
+  // if you are integrating with Recurly's 3D Secure support
+  if (body['three-d-secure-token']) {
+    billingInfo.three_d_secure_action_result_token_id = body['three-d-secure-token'];
+  }
+
+  // Create the purchase using minimal
+  // information: planCode, currency, account.code, and
+  // the token we generated on the frontend
+  const purchaseReq = {
+    subscriptions: [{ planCode: 'basic' }],
+    currency: 'USD',
+    account: { code, billingInfo }
+  };
+
+  try {
+    await client.createPurchase(purchaseReq);
+
+    return {
+      statusCode: 301,
+      headers: {
+        Location: process.env.SUCCESS_URL
+      }
+    };
+  } catch (err) {
+    // Here we handle a 3D Secure required error by redirecting to an authentication page
+    if (err && err.transactionError && err.transactionError.code === 'three_d_secure_action_required') {
+      const { threeDSecureActionTokenId } = err.transactionError;
+      const url = `/3d-secure/authenticate.html#token_id=${tokenId}&action_token_id=${threeDSecureActionTokenId}&account_code=${code}`;
+
+      return {
+        statusCode: 301,
+        headers: {
+          Location: url
+        }
+      };
+    }
+
+    // If any other error occurs, redirect to an error page with the error as a query param
+    const { message } = err;
+
+    return {
+      statusCode: 301,
+      headers: {
+        Location: `${process.env.ERROR_URL}?error=${message}`
+      }
+    };
+  }
+};

--- a/api/netlify/functions/update-account.js
+++ b/api/netlify/functions/update-account.js
@@ -1,0 +1,34 @@
+const recurly = require('recurly');
+
+const client = new recurly.Client(process.env.RECURLY_API_KEY);
+
+exports.handler = async (event, context) => {
+  const body = JSON.parse(event.body);
+  const account = event.path.split('/')[3];
+
+  try {
+    const accountUpdate = {
+      billing_info: {
+        token_id: body['recurly-token']
+      }
+    };
+
+    await client.updateAccount(account, accountUpdate);
+
+    return {
+        statusCode: 301,
+        headers: {
+          Location: process.env.SUCCESS_URL
+        }
+      };
+  } catch (err) {
+    const { message } = err;
+
+    return {
+      statusCode: 301,
+      headers: {
+        Location: `${process.env.ERROR_URL}?error=${message}`
+      }
+    };
+  }
+};

--- a/api/netlify/package-lock.json
+++ b/api/netlify/package-lock.json
@@ -1,0 +1,18 @@
+{
+  "name": "recurly-netlify-example",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "node-uuid": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+      "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
+    },
+    "recurly": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/recurly/-/recurly-3.14.1.tgz",
+      "integrity": "sha512-0HNZpgA7tls3t632UygVVcheoM/iwJe+16cNeAPda5yvrF8Ke2KqYf0AjA5jh0DyWRNbO50wJY66zAHpeq1Ukw=="
+    }
+  }
+}

--- a/api/netlify/package.json
+++ b/api/netlify/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "recurly-netlify-example",
+  "version": "1.0.0",
+  "description": "An integration example of Recurly with Netlify'",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/recurly/recurly-js-examples.git"
+  },
+  "author": "Dave Brudner",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/recurly/recurly-js-examples/issues"
+  },
+  "homepage": "https://github.com/recurly/recurly-js-examples#readme",
+  "dependencies": {
+    "node-uuid": "^1.4.1",
+    "recurly": "^3.14.1"
+  }
+}

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,30 @@
+[build]
+  publish = "public"
+  functions = "api/netlify/functions"
+  command = "cd api/netlify && npm install"
+
+[template.environment]
+  RECURLY_API_KEY = "Your Recurly PRIVATE key"
+  RECURLY_PUBLIC_KEY = "Your Recurly PUBLIC key"
+  SUCCESS_URL = "Redirect URL for new suscription success"
+  ERROR_URL = "Redirect URL for new subscription error"
+
+[[redirects]]
+  from = "/config"
+  to = "/.netlify/functions/config"
+  status = 200
+
+[[redirects]]
+  from = "/api/subscriptions/new"
+  to = "/.netlify/functions/new-subscription"
+  status = 200
+
+[[redirects]]
+  from = "/api/accounts/new"
+  to = "/.netlify/functions/new-account"
+  status = 200
+
+[[redirects]]
+  from = "/api/accounts/:account"
+  to = "/.netlify/functions/update-account/:account"
+  status = 200


### PR DESCRIPTION
Couple things to note:

1. The link for `deploy to netlify` won't work until this PR is merged (chicken or egg situation). To test, refer to https://app.netlify.com/start/deploy?repository=https://github.com/dbrudner/recurly-integration-examples

2. [Functions inside subdirectories isn't supported by netlify](https://github.com/netlify/netlify-lambda/issues/90). I added a `[[redirects]]` value in `netlify.toml` for each route to map to a netlify function.

3. I wanted to use the same text that we use in the heroku example for [describing environment variables on setup](https://github.com/recurly/recurly-integration-examples/blob/main/app.json#L6-L23), but it overflows on netlify (see img below), so I shortened the descriptions in `netlify.toml`.

![image](https://user-images.githubusercontent.com/32269552/96019809-aed00280-0e12-11eb-9dcb-31d9a85bf9fb.png)


