### PR TITLE
fix deploy node api with docker

### DIFF
--- a/api/node/app.js
+++ b/api/node/app.js
@@ -112,7 +112,7 @@ app.get('/config', function (req, res) {
 // Mounts express.static to render example forms
 const pubDirPath = PUBLIC_DIR_PATH || '/../../public';
 
-app.use(express.static(__dirname + pubDirPath));
+app.use(express.static(pubDirPath));
 
 // Start the server
 app.listen(9001, function () {

--- a/api/node/docker-compose.yml
+++ b/api/node/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 services:
   app:
     build:
@@ -12,4 +12,4 @@ services:
     env_file:
       - ../../docker.env
     environment:
-      - PUBLIC_DIR_PATH=/public
+      - PUBLIC_DIR_PATH=/usr/src/app/public


### PR DESCRIPTION
Deploy node api using docker is not working due to the PUBLIC_DIR_PATH is not propertly setted 