### PR TITLE
Add subscription.id to properly return addons

### DIFF
--- a/public/advanced-pricing/index.html
+++ b/public/advanced-pricing/index.html
@@ -200,7 +200,8 @@
                  + '<span data-recurly="currency_symbol"></span>'
                  + '<span data-recurly="addon_price" data-recurly-addon="' + addon.code + '"></span>'
                  + ')</label>'
-                 + '<input type="text" data-recurly="addon" data-recurly-addon="' + addon.code + '" value="0" id="addon-' + addon.code + '">';
+                 + '<input type="text" data-recurly="addon" data-recurly-addon="' + addon.code + '" value="0" id="addon-' + addon.code
+                 + '" data-recurly-subscription="' + plan.subscription.id + '">';
           }).join('');
         }
 


### PR DESCRIPTION
The example in advanced-pricing does not properly work with addons unless `data-recurly-subscription` is included. Makes for a very confusing example if/when it doesn't work.